### PR TITLE
Addressing User Story ID: US012420261208PM & Unrelated Changes

### DIFF
--- a/Control.py
+++ b/Control.py
@@ -30,9 +30,15 @@ class Controller:
 
             self.view.play_sound("assets/audio/ui_sound_01.wav", False)
             self.view.enable_create_preset_button(False)
+            self.view.enable_verify_button(False)
+            self.view.enable_clear_log_button(False)
+            self.view.enable_folder_button(False)
             self.view.log(f"\nCreating preset '{preset_name}' from: {self.model.verification_folder}")
             path = self.model._create_preset(preset_name)
             self.view.enable_create_preset_button(True)
+            self.view.enable_verify_button(True)
+            self.view.enable_clear_log_button(True)
+            self.view.enable_folder_button(True)
 
         except Exception as e:
             self.view.log(f"[Error] {e}")
@@ -52,14 +58,18 @@ class Controller:
 
             self.view.play_sound("assets/audio/ui_sound_01.wav", False)
             self.view.enable_create_preset_button(False)
-            self.view.enable_verify_preset_button(False)
+            self.view.enable_verify_button(False)
+            self.view.enable_clear_log_button(False)
+            self.view.enable_folder_button(False)
             self.view.log(f"Verifying hashes of {self.model.verification_folder} with preset '{preset_name}'")
             path = self.model._compare_hashes_with_preset(
                 folder_files_and_hashes=self.model._get_hashes(),
-                hashes_preset=self.model._load_preset("Example"),
+                hashes_preset=self.model._load_preset(self.view.get_preset_name_input().strip()),
                 preset_name=preset_name)
             self.view.enable_create_preset_button(True)
-            self.view.enable_verify_preset_button(True)
+            self.view.enable_verify_button(True)
+            self.view.enable_clear_log_button(True)
+            self.view.enable_folder_button(True)
 
         except Exception as e:
             self.view.log(f"[Error] {e}")

--- a/View.py
+++ b/View.py
@@ -19,6 +19,7 @@ class ViewHandles:
     verify_btn: int
     log_box: int
     folder_dialog: int
+    clear_log_btn: int
 
 
 class View:
@@ -213,6 +214,7 @@ class View:
             current_folder_text=current_folder_text,
             action_btn=action_btn,
             verify_btn=verify_btn,
+            clear_log_btn=clear_log_btn,
             log_box=log_box,
             folder_dialog=0,
         )
@@ -249,6 +251,10 @@ class View:
     def enable_verify_button(self, enabled: bool) -> None:
         assert self.handles is not None
         dpg.configure_item(self.handles.verify_btn, enabled=enabled)
+
+    def enable_clear_log_button(self, enabled: bool) -> None:
+        assert self.handles is not None
+        dpg.configure_item(self.handles.clear_log_btn, enabled=enabled)
 
     def log(self, msg: str, *, newline: bool = True) -> None:
         assert self.handles is not None


### PR DESCRIPTION
So that all UI buttons are disabled during preset creation, verification and clearing of logs executions. Finally so that, a bug was fixed where a hard coded preset name of 'Example' was being loaded instead of the currently chosen preset.